### PR TITLE
Search only through github merges

### DIFF
--- a/git-getpull
+++ b/git-getpull
@@ -9,7 +9,7 @@ elif [ -z "$(git rev-parse --git-dir 2>/dev/null)" ]; then
 else
   repository_path=$(git config --get remote.origin.url 2>/dev/null | perl -lne 'print $1 if /(?:(?:https?:\/\/github.com\/)|:)(.*?).git/')
   pull_base_url=https://github.com/$repository_path/pull
-  pull_id=$(git log $1..master --ancestry-path --merges --oneline 2>/dev/null | tail -n 1 | perl -nle 'print $1 if /#(\d+)/')
+  pull_id=$(git log $1..master --ancestry-path --merges --oneline 2>/dev/null  | grep 'Merge pull request' | tail -n 1 | perl -nle 'print $1 if /#(\d+)/')
 
   if [ -n "$pull_id" ]; then
     echo "$pull_base_url/$pull_id"


### PR DESCRIPTION
If the branch from which the PR came has a merge commit, ` git log $1..master --ancestry-path --merges --oneline` lists that merge commit too, and get-pull fails.