### PR TITLE
Fix edge case with merge commits in the PR

### DIFF
--- a/git-getpull
+++ b/git-getpull
@@ -9,7 +9,7 @@ elif [ -z "$(git rev-parse --git-dir 2>/dev/null)" ]; then
 else
   repository_path=$(git config --get remote.origin.url 2>/dev/null | perl -lne 'print $1 if /(?:(?:https?:\/\/github.com\/)|:)(.*?)(.git)?$/')
   pull_base_url=https://github.com/$repository_path/pull
-  pull_id=$(git log $1..master --ancestry-path --merges --oneline 2>/dev/null | tail -n 1 | perl -nle 'print $1 if /#(\d+)/')
+  pull_id=$(git log $1..master --ancestry-path --merges --oneline 2>/dev/null | perl -nle 'print $1 if /#(\d+)/' | tail -n 1)
 
   if [ -n "$pull_id" ]; then
     echo "$pull_base_url/$pull_id"


### PR DESCRIPTION
This fixes what #2 was supposed to fix by using perl to print out
the pull number only if it can find it and _then_ using `tail` to
take the last line of output. Before this, the script would fail if
the last line of output was a merge commit on the pull request
branch rather than the pull request merge commit on master.

For example, this fixes the error for this git log output:

```
c4390ec Merge pull request #5025 from <redacted>
42e7e9d Merge pull request #5020 from <redacted>
8f81486 Merge pull request #4655 from <redacted>serialization
1fb888d Merge branch '<redacted>' of https://github.com/<redacted> into <redacted>
2b3137f Merge master into <redacted>
```